### PR TITLE
feat: allow values local_file creation to be optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -108,6 +108,10 @@ data "aws_region" "current" {}
 
 locals {
   region = var.region != "" ? var.region : data.aws_region.current.region
+  values_content = [
+    for p in zesty_account.result.account.products : p.values
+    if p.name == "Kompass" && p.active == true
+  ][0]
 }
 
 resource "zesty_account" "result" {
@@ -123,10 +127,13 @@ resource "zesty_account" "result" {
 }
 
 resource "local_file" "kompass_values" {
-  content = [
-    for p in zesty_account.result.account.products : p.values
-    if p.name == "Kompass" && p.active == true
-  ][0]
+  count      = var.create_values_local_file ? 1 : 0
+  content    = local.values_content
   filename   = var.values_yaml_filename
   depends_on = [zesty_account.result]
+}
+
+moved {
+  from = local_file.kompass_values
+  to   = local_file.kompass_values[1]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "kompass_values_yaml" {
-  value       = local_file.kompass_values.content
+  value       = local.values_content
   description = "The contents of the values.yaml file used to onboard Kompass"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -42,3 +42,9 @@ variable "values_yaml_filename" {
   type        = string
   default     = "values.yaml"
 }
+
+variable "create_values_local_file" {
+  description = "Enables the creation of a local values.yaml file"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
The module creates a few resources. One of those is a `local_file` which contains the helm values files. Due to the fact that we are running terraform plan and apply in CI, this file is always a drift in our plans.

This PR just adds a variable to make the `local_file` creation optional.